### PR TITLE
Fix breaking CI builds (dashing, eloquent)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,10 @@ jobs:
       matrix:
         # os: [ ubuntu-20.04, windows-latest, macOS-latest ]
         os: [ ubuntu-20.04 ]
-        ros_distribution: [ foxy, rolling, eloquent, dashing ]
+        ros_distribution: [ foxy, rolling, dashing ]
         include:
           - docker_image: ubuntu:bionic
             ros_distribution: dashing
-
-          - docker_image: ubuntu:bionic
-            ros_distribution: eloquent
 
           - docker_image: ubuntu:focal
             ros_distribution: foxy
@@ -34,14 +31,15 @@ jobs:
       image: ${{ matrix.docker_image }}
     steps:
     - uses: actions/checkout@v2
-    - uses: ros-tooling/setup-ros@0.0.26
+    - uses: ros-tooling/setup-ros@0.1.2
       with:
         required-ros-distributions: ${{ matrix.ros_distribution }}
     - name : Download and install rclc-dependencies
       run: |
         apt-get install ros-${{ matrix.ros_distribution }}-rclc
         apt-get install ros-${{ matrix.ros_distribution }}-osrf-testing-tools-cpp
-    - uses : ros-tooling/action-ros-ci@0.1.0
+        pip3 install setuptools_rust
+    - uses : ros-tooling/action-ros-ci@0.1.1
       with:
         package-name: "micro_ros_diagnostic_msgs micro_ros_diagnostic_updater micro_ros_common_diagnostics"
         vcs-repo-file-url: ""


### PR DESCRIPTION
*Drop eloquent (EOL)
* update ROS actions

Signed-off-by: Nordmann Arne (CR/ADT3) <arne.nordmann@de.bosch.com>