### PR TITLE
Un-string-ify micro-ROS diagnostics

### DIFF
--- a/micro_ros_diagnostic_bridge/CMakeLists.txt
+++ b/micro_ros_diagnostic_bridge/CMakeLists.txt
@@ -1,0 +1,65 @@
+cmake_minimum_required(VERSION 3.5)
+project(micro_ros_diagnostic_bridge)
+
+# Default to C99
+if(NOT CMAKE_C_STANDARD)
+  set(CMAKE_C_STANDARD 99)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(diagnostic_msgs REQUIRED)
+find_package(micro_ros_diagnostic_msgs REQUIRED)
+find_package(rclcpp REQUIRED)
+
+# bridge executable
+include_directories(include)
+add_executable(diagnostic_bridge
+  src/diagnostic_bridge_node.cpp
+  src/micro_ros_diagnostic_bridge/micro_ros_diagnostic_bridge.cpp)
+target_include_directories(diagnostic_bridge
+    PUBLIC
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>
+    PRIVATE
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
+)
+ament_target_dependencies(diagnostic_bridge
+  rclcpp
+  diagnostic_msgs
+  micro_ros_diagnostic_msgs
+)
+install(TARGETS diagnostic_bridge
+  DESTINATION lib/${PROJECT_NAME})
+
+# launch
+install(DIRECTORY launch DESTINATION share/${PROJECT_NAME}/)
+
+# install
+install(DIRECTORY include/ DESTINATION include)
+
+ament_export_include_directories(include)
+ament_export_libraries(${PROJECT_NAME})
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+  find_package(ament_lint_auto REQUIRED)
+  find_package(osrf_testing_tools_cpp REQUIRED)
+  find_package(ros_environment REQUIRED)
+
+  # the following line skips the linter which checks for copyrights
+  # remove the line when a copyright and license is present in all source files
+  set(ament_cmake_copyright_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+# export dependencies
+# specific order: dependents before dependencies
+ament_export_include_directories(include)
+ament_export_libraries(${PROJECT_NAME})
+ament_export_dependencies(ament_cmake)
+ament_export_dependencies(micro_ros_diagnostic_msgs)
+ament_export_dependencies(rosidl_generator_c)
+ament_export_dependencies(rcl)
+ament_export_dependencies(rcutils)
+ament_package()

--- a/micro_ros_diagnostic_bridge/README.md
+++ b/micro_ros_diagnostic_bridge/README.md
@@ -1,10 +1,10 @@
 General information about this repository, including legal information, build instructions and known issues/limitations, can be found in the [README](../README.md) of the repository root.
 
-# The micro-ROS diagnostic updater package
+# The micro-ROS diagnostic bridge package
 
-micro-ROS diagnostic updater is a [ROS 2](http://www.ros2.org/) package that provides convenience functions to implement diagnostic tasks amd updaters based on the ROS Client C-Library (RCLC) for micro-ROS.
+micro-ROS diagnostic bridge is a [ROS 2](http://www.ros2.org/) package that provides a bridge to translate micro-ROS diagnostic messages to vanilla ROS 2 diagnostic messages based on a lookup table.
 
-An exemplary implementation can be found in: [example/example_updater.c](example_updater.c)
+An exemplary lookup table can be found in: [example_table.yaml](example_table.yaml)
 
 ## Purpose of the Project
 
@@ -17,8 +17,8 @@ standards, e.g., ISO 26262.
 
 ## How to Build, Test, Install, and Use
 
-After you cloned this repository into your ROS 2 workspace folder, you may build and install it using colcon:  
-$ `colcon build --packages-select micro_ros_diagnostic_updater`
+After you cloned this repository into your ROS 2 workspace folder, you may build and install it using colcon:
+$ `colcon build --packages-select micro_ros_diagnostic_bridge`
 
 ## License
 

--- a/micro_ros_diagnostic_bridge/README.md
+++ b/micro_ros_diagnostic_bridge/README.md
@@ -1,0 +1,32 @@
+General information about this repository, including legal information, build instructions and known issues/limitations, can be found in the [README](../README.md) of the repository root.
+
+# The micro-ROS diagnostic updater package
+
+micro-ROS diagnostic updater is a [ROS 2](http://www.ros2.org/) package that provides convenience functions to implement diagnostic tasks amd updaters based on the ROS Client C-Library (RCLC) for micro-ROS.
+
+An exemplary implementation can be found in: [example/example_updater.c](example_updater.c)
+
+## Purpose of the Project
+
+This software is not ready for production use. It has neither been developed nor
+tested for a specific use case. However, the license conditions of the
+applicable Open Source licenses allow you to adapt the software to your needs.
+Before using it in a safety relevant setting, make sure that the software
+fulfills your requirements and adjust it according to any applicable safety
+standards, e.g., ISO 26262.
+
+## How to Build, Test, Install, and Use
+
+After you cloned this repository into your ROS 2 workspace folder, you may build and install it using colcon:  
+$ `colcon build --packages-select micro_ros_diagnostic_updater`
+
+## License
+
+The micro-ROS diagnostics framework packages are open-sourced under the Apache-2.0 license. See the [../LICENSE](LICENSE) file for details.
+
+For a list of other open-source components included in ROS 2 system_modes,
+see the file [../3rd-party-licenses.txt](3rd-party-licenses.txt).
+
+## Acknowledgments
+
+This activity has received funding from the European Research Council (ERC) under the European Union's Horizon 2020 research and innovation programme (grant agreement n° 780785).

--- a/micro_ros_diagnostic_bridge/example_table.yaml
+++ b/micro_ros_diagnostic_bridge/example_table.yaml
@@ -1,0 +1,29 @@
+# bridge lookup table
+---
+
+hardware_ids:
+  ros__parameters:
+    00: esp32_01
+    17: esp32_foo
+    42: esp32_bar
+
+updaters:
+  ros__parameters:
+    00:
+      name: "google.com checker"
+      description: "Periodically checks the website google.com for availability."
+      keys:
+        23:
+          name: "return code"
+          values:
+            200: "ok"
+            404: "not found"
+            500: "server error"
+    17:
+      name: "Processor info"
+      description: "Measuring processor temperature and load."
+      keys:
+        00:
+          name: "temp"
+        01:
+          name: "load"

--- a/micro_ros_diagnostic_bridge/include/micro_ros_diagnostic_bridge/micro_ros_diagnostic_bridge.hpp
+++ b/micro_ros_diagnostic_bridge/include/micro_ros_diagnostic_bridge/micro_ros_diagnostic_bridge.hpp
@@ -1,0 +1,57 @@
+// Copyright (c) 2018 - for information on the respective copyright owner
+// see the NOTICE file and/or the repository https://github.com/microros/system_modes
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "diagnostic_msgs/msg/diagnostic_status.hpp"
+#include "micro_ros_diagnostic_msgs/msg/micro_ros_diagnostic_status.hpp"
+
+
+static const char UROS_DIAGNOSTICS_BRIDGE_TOPIC_IN[]  = "/diagnostics_uros";
+static const char UROS_DIAGNOSTICS_BRIDGE_TOPIC_OUT[] = "/diagnostics";
+
+namespace uros_diagnostic_msg = micro_ros_diagnostic_msgs::msg;
+namespace diagnostic_msg = diagnostic_msgs::msg;
+
+typedef std::pair<unsigned int, unsigned int> DiagnosticKey;
+typedef std::tuple<unsigned int, unsigned int, unsigned int> ValueLookup;
+
+typedef std::map<unsigned int, std::string> HardwareMap;
+typedef std::map<unsigned int, std::pair<std::string, std::string>> UpdaterMap;
+typedef std::map<DiagnosticKey, std::string> KeyMap;
+typedef std::map<ValueLookup, std::string> ValueMap;
+
+class MicroROSDiagnosticBridge : public rclcpp::Node
+{
+public:
+    MicroROSDiagnosticBridge();
+protected:
+  virtual void read_lookup_table(const std::string & path);
+  virtual const std::string lookup_hardware(unsigned int hardware_id);
+  virtual const std::pair<std::string, std::string> lookup_updater(unsigned int updater_id);
+  virtual const std::string lookup_key(unsigned int updater_id, unsigned int key);
+  virtual const std::string lookup_value(unsigned int updater_id, unsigned int key, unsigned int value_id);
+
+  rclcpp::Logger logger_;
+  rclcpp::Subscription<uros_diagnostic_msg::MicroROSDiagnosticStatus>::SharedPtr uros_sub_;
+  rclcpp::Publisher<diagnostic_msg::DiagnosticStatus>::SharedPtr ros2_pub_;
+  std::unique_ptr<diagnostic_msg::DiagnosticStatus> msg_out_;
+
+  HardwareMap hardware_map_;
+  UpdaterMap updater_map_;
+  KeyMap key_map_;
+  ValueMap value_map_;
+};

--- a/micro_ros_diagnostic_bridge/launch/diagnostic_bridge.launch.py
+++ b/micro_ros_diagnostic_bridge/launch/diagnostic_bridge.launch.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2019 - for information on the respective copyright owner
+# see the NOTICE file and/or the repository https://github.com/micro-ROS/system_modes.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import launch
+import launch.actions
+import launch.substitutions
+
+import launch_ros.actions
+
+
+def generate_launch_description():
+    return launch.LaunchDescription([
+        launch.actions.DeclareLaunchArgument(
+            'lookup_table',
+            description='Path to lookup table'),
+        launch_ros.actions.Node(
+            package='micro_ros_diagnostic_bridge',
+            executable='diagnostic_bridge',
+            parameters=[{'lookup_table': launch.substitutions.LaunchConfiguration('lookup_table')}],
+            output='screen')])

--- a/micro_ros_diagnostic_bridge/package.xml
+++ b/micro_ros_diagnostic_bridge/package.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>micro_ros_diagnostic_bridge</name>
+  <version>0.2.0</version>
+  <description>Bridges micro-ROS diagnostic messages and vanilla ROS 2 diagnostic messages.</description>
+  <maintainer email="arne.nordmann@de.bosch.com">Arne Nordmann</maintainer>
+
+  <license>Apache License 2.0</license>
+
+  <author email="arne.nordmann@de.bosch.com">Arne Nordmann</author>
+
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
+
+  <depend>diagnostic_msgs</depend>
+  <depend>micro_ros_diagnostic_msgs</depend>
+  <depend>rclcpp</depend>
+
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+  <test_depend>diagnostic_msgs</test_depend>
+  <test_depend>micro_ros_diagnostic_msgs</test_depend>
+  <test_depend>osrf_testing_tools_cpp</test_depend>
+  <test_depend>ros_environment</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/micro_ros_diagnostic_bridge/src/diagnostic_bridge_node.cpp
+++ b/micro_ros_diagnostic_bridge/src/diagnostic_bridge_node.cpp
@@ -1,0 +1,10 @@
+#include "micro_ros_diagnostic_bridge/micro_ros_diagnostic_bridge.hpp"
+
+
+int main(int argc, char **argv)
+{
+    rclcpp::init(argc, argv);
+    auto node = std::make_shared<MicroROSDiagnosticBridge>();
+    rclcpp::spin(node);
+    rclcpp::shutdown();
+}

--- a/micro_ros_diagnostic_bridge/src/micro_ros_diagnostic_bridge/micro_ros_diagnostic_bridge.cpp
+++ b/micro_ros_diagnostic_bridge/src/micro_ros_diagnostic_bridge/micro_ros_diagnostic_bridge.cpp
@@ -1,0 +1,226 @@
+// Copyright (c) 2018 - for information on the respective copyright owner
+// see the NOTICE file and/or the repository https://github.com/microros/system_modes
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "micro_ros_diagnostic_bridge/micro_ros_diagnostic_bridge.hpp"
+
+#include <rcl/error_handling.h>
+
+#include <rclcpp/parameter.hpp>
+#include <rclcpp/parameter_map.hpp>
+#include <rcl_yaml_param_parser/parser.h>
+
+using micro_ros_diagnostic_msgs::msg::MicroROSDiagnosticStatus;
+using diagnostic_msgs::msg::DiagnosticStatus;
+
+MicroROSDiagnosticBridge::MicroROSDiagnosticBridge()
+: Node("micro_ros_diagnostic_bridge"),
+  logger_(rclcpp::get_logger("MicroROSDiagnosticBridge"))
+{
+  // Read lookup table
+  declare_parameter("lookup_table", rclcpp::ParameterValue(std::string("")));
+  std::string model_path = get_parameter("lookup_table").as_string();
+  if (model_path.empty()) {
+    throw std::invalid_argument("Need path to lookup table.");
+  }
+  this->read_lookup_table(model_path);
+
+  auto callback =
+    [this](const MicroROSDiagnosticStatus::SharedPtr msg_in) -> void
+    {
+      RCLCPP_DEBUG(
+        this->get_logger(),
+        "Bridging message from hardware %d, updater %d",
+        msg_in->hardware_id, msg_in->updater_id);
+      msg_out_ = std::make_unique<diagnostic_msgs::msg::DiagnosticStatus>();
+
+      auto updater = this->lookup_updater(msg_in->updater_id);
+      auto hardware = this->lookup_hardware(msg_in->hardware_id);
+      msg_out_->hardware_id = hardware;
+      msg_out_->name = updater.first;
+      msg_out_->message = updater.second;
+      msg_out_->level = msg_in->level;
+
+      diagnostic_msgs::msg::KeyValue keyvalue;
+      keyvalue.key = this->lookup_key(msg_in->updater_id, msg_in->key);
+      switch (msg_in->value_type) {
+        case micro_ros_diagnostic_msgs::msg::MicroROSDiagnosticStatus::VALUE_BOOL:
+          keyvalue.value = std::to_string(msg_in->bool_value);
+          break;
+        case micro_ros_diagnostic_msgs::msg::MicroROSDiagnosticStatus::VALUE_INT:
+          keyvalue.value = std::to_string(msg_in->int_value);
+          break;
+        case micro_ros_diagnostic_msgs::msg::MicroROSDiagnosticStatus::VALUE_DOUBLE:
+          keyvalue.value = std::to_string(msg_in->double_value);
+          break;
+        case micro_ros_diagnostic_msgs::msg::MicroROSDiagnosticStatus::VALUE_LOOKUP:
+          keyvalue.value = this->lookup_value(msg_in->updater_id, msg_in->key, msg_in->value_id);
+          break;
+      }
+      msg_out_->values.push_back(keyvalue);
+
+      ros2_pub_->publish(std::move(msg_out_));
+    };
+
+    // Create a subscription to the topic which can be matched with one or more compatible ROS
+    // publishers.
+    // Note that not all publishers on the same topic with the same type will be compatible:
+    // they must have compatible Quality of Service policies.
+    uros_sub_ = create_subscription<MicroROSDiagnosticStatus>(
+        UROS_DIAGNOSTICS_BRIDGE_TOPIC_IN,
+        rclcpp::SystemDefaultsQoS(),
+        callback);
+    ros2_pub_ = this->create_publisher<DiagnosticStatus>(
+      UROS_DIAGNOSTICS_BRIDGE_TOPIC_OUT,
+      rclcpp::SystemDefaultsQoS());
+}
+
+const std::string
+MicroROSDiagnosticBridge::lookup_key(
+  unsigned int updater_id,
+  unsigned int key)
+{
+  try {
+    return key_map_.at(std::make_pair(updater_id, key));
+  } catch (std::out_of_range & e) {
+    RCLCPP_ERROR(
+      this->get_logger(),
+      "Trying to bridge diagnostic message with updater %d and key %d, but couldn't find key in lookup table.",
+      updater_id, key);
+    return "NOTFOUND";
+  }
+}
+
+const std::string
+MicroROSDiagnosticBridge::lookup_value(
+  unsigned int updater_id,
+  unsigned int key,
+  unsigned int value_id)
+{
+  try {
+    return value_map_.at(std::make_tuple(updater_id, key, value_id));
+  } catch (std::out_of_range & e) {
+    RCLCPP_ERROR(
+      this->get_logger(),
+      "Trying to bridge diagnostic message with updater %d, key %d, and value id %d, but couldn't find keys in lookup table.",
+      updater_id, key, value_id);
+    return "NOTFOUND";
+  }
+}
+
+const std::string
+MicroROSDiagnosticBridge::lookup_hardware(unsigned int hardware_id)
+{
+  try {
+    return hardware_map_.at(hardware_id);
+  } catch (std::out_of_range & e) {
+    RCLCPP_ERROR(
+      this->get_logger(),
+      "Trying to bridge diagnostic message with hardware_id %d, but couldn't find ID in lookup table.",
+      hardware_id);
+    return "NOTFOUND";
+  }
+}
+
+const std::pair<std::string, std::string>
+MicroROSDiagnosticBridge::lookup_updater(unsigned int updater_id)
+{
+  try {
+    return updater_map_.at(updater_id);
+  } catch (std::out_of_range & e) {
+    RCLCPP_ERROR(
+      this->get_logger(),
+      "Trying to bridge diagnostic message with updater_id %d, but couldn't find ID in lookup table.",
+      updater_id);
+    return std::make_pair("NOTFOUND", "NOTFOUND");
+  }
+}
+
+void
+MicroROSDiagnosticBridge::read_lookup_table(const std::string & path)
+{
+  rcl_params_t * yaml_params = rcl_yaml_node_struct_init(rcl_get_default_allocator());
+  if (!rcl_parse_yaml_file(path.c_str(), yaml_params)) {
+    throw std::runtime_error("Failed to parse parameters " + path + ". " + rcl_get_error_string().str);
+  }
+
+  rclcpp::ParameterMap param_map = rclcpp::parameter_map_from(yaml_params);
+  rcl_yaml_node_struct_fini(yaml_params);
+
+  rclcpp::ParameterMap::iterator it;
+  for (it = param_map.begin(); it != param_map.end(); it++) {
+    if (it->first.compare("/hardware_ids") == 0) {
+      for (auto & p : it->second) {
+        this->hardware_map_[std::stoi(p.get_name())] = p.value_to_string();
+      }
+    }
+
+    if (it->first.compare("/updaters") == 0) {
+      std::string updater_key, updater_name, updater_descr, key, key_name;
+      for (auto & p : it->second) {
+        auto pos = p.get_name().find('.');
+        if (pos != std::string::npos) {
+          updater_key = p.get_name().substr(0, pos);
+        }
+
+        // Updater
+        if (p.get_name().compare(updater_key + ".name") == 0) {
+          updater_name = p.value_to_string();
+          updater_map_[std::stoi(updater_key)] = std::make_pair(updater_name, updater_descr);
+        }
+        if (p.get_name().compare(updater_key + ".description") == 0) {
+          updater_descr = p.value_to_string();
+          updater_map_[std::stoi(updater_key)] = std::make_pair(updater_name, updater_descr);
+        }
+
+        // Keys
+        if (p.get_name().rfind(updater_key + ".keys", 0) == 0) {
+          auto start = updater_key.length() + 6;
+          pos = p.get_name().find('.', start);
+          key = p.get_name().substr(start, pos - start);
+        }
+        if (p.get_name().compare(updater_key + ".keys." + key + ".name") == 0) {
+          key_name = p.value_to_string();
+          key_map_[std::make_pair(std::stoi(updater_key), std::stoi(key))] = key_name;
+        }
+
+        // Values lookup
+        if (p.get_name().rfind(updater_key + ".keys." + key + ".values") == 0) {
+          auto start = updater_key.length() + key.length() + 14;
+          pos = p.get_name().find('.', start);
+          auto value = std::stoi(p.get_name().substr(start, pos - start));
+          value_map_[std::make_tuple(std::stoi(updater_key), std::stoi(key), value)] = p.value_to_string();
+        }
+      }
+    }
+  }
+
+  // Debug
+  RCLCPP_INFO(get_logger(), "Lookup table:");
+  RCLCPP_INFO(get_logger(), " Found %lu hardware keys.", hardware_map_.size());
+  RCLCPP_INFO(get_logger(), " Found %lu updaters.", updater_map_.size());
+  for (auto const& k : updater_map_) {
+    RCLCPP_DEBUG(
+      get_logger(), "  Updater %d : %s(%s)",
+      k.first, k.second.first.c_str(), k.second.second.c_str());
+  }
+  RCLCPP_INFO(
+    get_logger(), " Found %lu diagnostic keys with %lu diagnostic values.",
+    key_map_.size(), value_map_.size());
+  for (auto const& k : value_map_) {
+    RCLCPP_DEBUG(
+      get_logger(), "  Value %d,%d,%d : %s",
+      std::get<0>(k.first), std::get<1>(k.first), std::get<2>(k.first),
+      k.second.c_str());
+  }
+}

--- a/micro_ros_diagnostic_msgs/msg/MicroROSDiagnosticStatus.msg
+++ b/micro_ros_diagnostic_msgs/msg/MicroROSDiagnosticStatus.msg
@@ -1,9 +1,10 @@
 # This message holds the status of an individual component of the robot.
 #
-# This message specification is a copy of
+# This message specification is inspired by
 # common_interfaces/diagnostic_msgs/msg/DiagnosticStatus.msg
 # with the difference that it comprises just one key and value
-# instead of an array of KeyValue messages.
+# instead of an array of KeyValue messages as well as avoiding
+# any strings.
 
 # Possible levels of operations.
 byte OK=0
@@ -11,15 +12,25 @@ byte WARN=1
 byte ERROR=2
 byte STALE=3
 
+# Possible value types
+byte VALUE_BOOL=1
+byte VALUE_INT=2
+byte VALUE_DOUBLE=3
+byte VALUE_LOOKUP=10
+
 # Level of operation enumerated above.
 byte level
+
 # A description of the test/component reporting.
-string name
-# A description of the status.
-string message
+uint8 updater_id
 # A hardware unique string.
-string hardware_id
-# What to label this value when viewing.
-string key
-# A value to track over time.
-string value
+uint8 hardware_id
+
+# What key, value is transmitted.
+uint8 key
+
+byte value_type
+bool bool_value
+int64 int_value
+float64 double_value
+int64 value_id

--- a/micro_ros_diagnostic_updater/CMakeLists.txt
+++ b/micro_ros_diagnostic_updater/CMakeLists.txt
@@ -42,9 +42,17 @@ ament_target_dependencies(${PROJECT_NAME}
 )
 
 include_directories(include)
-add_executable(example_updater example/example_updater.c)
-target_link_libraries(example_updater ${PROJECT_NAME})
-ament_target_dependencies(example_updater
+
+add_executable(example_processor_updater example/example_processor_updater.c)
+target_link_libraries(example_processor_updater ${PROJECT_NAME})
+ament_target_dependencies(example_processor_updater
+  rclc
+  rcutils
+  micro_ros_diagnostic_msgs)
+
+add_executable(example_website_checker example/example_website_checker.c)
+target_link_libraries(example_website_checker ${PROJECT_NAME})
+ament_target_dependencies(example_website_checker
   rclc
   rcutils
   micro_ros_diagnostic_msgs)

--- a/micro_ros_diagnostic_updater/example/example_processor_updater.c
+++ b/micro_ros_diagnostic_updater/example/example_processor_updater.c
@@ -22,16 +22,40 @@
 
 static int my_diagnostic_temp = 0;
 
-const char * my_diagnostic_function()
+rcl_ret_t
+my_diagnostic_temperature(diagnostic_value_t * temp_kv)
 {
-  static char dvalue[20] = "xx degrees";
+  // Fake a temperature
   ++my_diagnostic_temp;
   if (my_diagnostic_temp > 99) {
     my_diagnostic_temp -= 0;
   }
-  snprintf(dvalue, sizeof(dvalue), "%d degrees", my_diagnostic_temp);
+  rclc_diagnostic_value_set_int(temp_kv, my_diagnostic_temp);
 
-  return dvalue;
+  // Calculate the diagnostic level
+  if (my_diagnostic_temp > 85) {
+    rclc_diagnostic_value_set_level(temp_kv, 2);
+  } else if (my_diagnostic_temp > 75) {
+    rclc_diagnostic_value_set_level(temp_kv, 1);
+  } else {
+    rclc_diagnostic_value_set_level(temp_kv, 0);
+  }
+  return RCL_RET_OK;
+}
+
+rcl_ret_t
+my_diagnostic_load(diagnostic_value_t * load_kv)
+{
+  // Fake a processor load
+  rclc_diagnostic_value_set_int(load_kv, my_diagnostic_temp / 2);
+
+  // Calculate the diagnostic level
+  if (my_diagnostic_temp > 46) {
+    rclc_diagnostic_value_set_level(load_kv, 1);
+  } else {
+    rclc_diagnostic_value_set_level(load_kv, 0);
+  }
+  return RCL_RET_OK;
 }
 
 int main(int argc, const char * argv[])
@@ -71,47 +95,59 @@ int main(int argc, const char * argv[])
 
   // updater
   diagnostic_updater_t updater;
-  rc = rclc_diagnostic_updater_init(
-    &updater,
-    &my_node,
-    "my_updater",
-    "mocked hardware monitoring",
-    "hw-id-42");
+  rc = rclc_diagnostic_updater_init(&updater, &my_node, 17, 42);
   if (rc != RCL_RET_OK) {
     printf("Error in creating diagnostic updater\n");
     return -1;
   }
-
   diagnostic_task_t task;
   rc = rclc_diagnostic_task_init(
-    &task,
-    "my_temperatur",
-    &my_diagnostic_function);
+    &task, 0,
+    &my_diagnostic_temperature);
   if (rc != RCL_RET_OK) {
     printf("Error in creating diagnostic task\n");
     return -1;
   }
+  diagnostic_task_t ltask;
+  rc = rclc_diagnostic_task_init(
+    &ltask, 1,
+    &my_diagnostic_load);
+  if (rc != RCL_RET_OK) {
+    printf("Error in creating diagnostic website checker\n");
+    return -1;
+  }
 
+  // adding tasks
   rc = rclc_diagnostic_updater_add_task(
     &updater,
     &task);
   if (rc != RCL_RET_OK) {
-    printf("Error in adding diagnostic task\n");
+    printf("Error in adding diagnostic temp task\n");
+    return -1;
+  }
+  rc = rclc_diagnostic_updater_add_task(
+    &updater,
+    &ltask);
+  if (rc != RCL_RET_OK) {
+    printf("Error in adding diagnostic website task\n");
     return -1;
   }
 
-  for (unsigned int i = 0; i < 2; ++i) {
+  for (unsigned int i = 0; i < 100; ++i) {
+    printf("Publishing processor diagnostics\n");
     rc = rclc_diagnostic_updater_update(&updater);
     if (rc != RCL_RET_OK) {
-      printf("Error in publishing diagnostics\n");
+      printf("Error in publishing temp diagnostics\n");
       return -1;
     }
     sleep(1);
   }
 
+  rclc_diagnostic_updater_fini(&updater, &my_node);
   if (rc != RCL_RET_OK) {
     printf("Error while cleaning up!\n");
     return -1;
   }
+
   return 0;
 }

--- a/micro_ros_diagnostic_updater/example/example_website_checker.c
+++ b/micro_ros_diagnostic_updater/example/example_website_checker.c
@@ -1,0 +1,126 @@
+// Copyright (c) 2020 - for information on the respective copyright owner
+// see the NOTICE file and/or the repository
+// https://github.com/micro-ROS/micro_ros_diagnostics.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <stdio.h>
+#include <unistd.h>
+
+#include <rclc/executor.h>
+
+#include <micro_ros_diagnostic_updater/micro_ros_diagnostic_updater.h>
+#include <micro_ros_diagnostic_msgs/msg/micro_ros_diagnostic_status.h>
+
+static int my_diagnostic_status = 0;
+static int my_website_status = 0;
+
+rcl_ret_t
+my_diagnostic_website_check(diagnostic_value_t * kv)
+{
+  ++my_diagnostic_status;
+  if (my_diagnostic_status > 99) {
+    my_diagnostic_status -= 0;
+  }
+  if (my_diagnostic_status % 13 == 0) {
+    my_website_status = 404;
+    rclc_diagnostic_value_set_level(kv, 1);
+  } else if (my_diagnostic_status % 17 == 0) {
+    my_website_status = 500;
+    rclc_diagnostic_value_set_level(kv, 2);
+  } else {
+    my_website_status = 200;
+    rclc_diagnostic_value_set_level(kv, micro_ros_diagnostic_msgs__msg__MicroROSDiagnosticStatus__OK);
+  }
+  rclc_diagnostic_value_lookup(kv, my_website_status);
+
+  return RCL_RET_OK;
+}
+
+int main(int argc, const char * argv[])
+{
+  rcl_context_t context = rcl_get_zero_initialized_context();
+  rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
+  rcl_allocator_t allocator = rcl_get_default_allocator();
+  rcl_ret_t rc;
+
+  // create init_options
+  rc = rcl_init_options_init(&init_options, allocator);
+  if (rc != RCL_RET_OK) {
+    printf("Error rcl_init_options_init.\n");
+    return -1;
+  }
+
+  // create context
+  rc = rcl_init(argc, argv, &init_options, &context);
+  if (rc != RCL_RET_OK) {
+    printf("Error in rcl_init.\n");
+    return -1;
+  }
+
+  // create rcl_node
+  rcl_node_t my_node = rcl_get_zero_initialized_node();
+  rcl_node_options_t node_ops = rcl_node_get_default_options();
+  rc = rcl_node_init(
+    &my_node,
+    "node_0",
+    "",
+    &context,
+    &node_ops);
+  if (rc != RCL_RET_OK) {
+    printf("Error in rcl_node_init\n");
+    return -1;
+  }
+
+  // updater
+  diagnostic_updater_t updater;
+  rc = rclc_diagnostic_updater_init(&updater, &my_node, 00, 42);
+  if (rc != RCL_RET_OK) {
+    printf("Error in creating diagnostic updater\n");
+    return -1;
+  }
+  diagnostic_task_t task;
+  rc = rclc_diagnostic_task_init(
+    &task, 23,
+    &my_diagnostic_website_check);
+  if (rc != RCL_RET_OK) {
+    printf("Error in creating diagnostic task\n");
+    return -1;
+  }
+
+  // adding tasks
+  rc = rclc_diagnostic_updater_add_task(
+    &updater,
+    &task);
+  if (rc != RCL_RET_OK) {
+    printf("Error in adding diagnostic temp task\n");
+    return -1;
+  }
+
+  for (unsigned int i = 0; i < 100; ++i) {
+    printf("Publishing website diagnostics\n");
+    rc = rclc_diagnostic_updater_update(&updater);
+    if (rc != RCL_RET_OK) {
+      printf("Error in publishing website diagnostics\n");
+      return -1;
+    }
+    sleep(1);
+  }
+
+  rclc_diagnostic_updater_fini(&updater, &my_node);
+  if (rc != RCL_RET_OK) {
+    printf("Error while cleaning up!\n");
+    return -1;
+  }
+
+  return 0;
+}

--- a/micro_ros_diagnostic_updater/include/micro_ros_diagnostic_updater/micro_ros_diagnostic_updater.h
+++ b/micro_ros_diagnostic_updater/include/micro_ros_diagnostic_updater/micro_ros_diagnostic_updater.h
@@ -22,42 +22,61 @@
 
 #define MICRO_ROS_UPDATER_MAX_NUMBER_OF_TASKS 5
 
-typedef struct diagnostic_key_value_t
+typedef struct diagnostic_value_t
 {
-  const char * key;
-  const char * value;
-} diagnostic_key_value_t;
+  unsigned int value_type;
+  bool bool_value;
+  int int_value;
+  double double_value;
+  unsigned int value_id;
+
+  unsigned int level;
+} diagnostic_value_t;
 
 typedef struct diagnostic_task_t
 {
-  const char * name;
-  const char * (*function)(void);
+  unsigned int id;
+  diagnostic_value_t value;
+  rcl_ret_t (*function)(diagnostic_value_t*);
 } diagnostic_task_t;
 
 typedef struct diagnostic_updater_t
 {
-  const char * name;
-  const char * message;
-  const char * hardware_id;
-  int num_tasks;
+  unsigned int id;
+  unsigned int hardware_id;
+  unsigned int num_tasks;
   diagnostic_task_t * tasks[MICRO_ROS_UPDATER_MAX_NUMBER_OF_TASKS];
   rcl_publisher_t diag_pub;
   micro_ros_diagnostic_msgs__msg__MicroROSDiagnosticStatus diag_status;
 } diagnostic_updater_t;
 
+void
+rclc_diagnostic_value_set_int(
+  diagnostic_value_t * kv,
+  const int value);
+
+void
+rclc_diagnostic_value_lookup(
+  diagnostic_value_t * kv,
+  const unsigned int value_id);
+
+void
+rclc_diagnostic_value_set_level(
+  diagnostic_value_t * kv,
+  const unsigned int level);
+
 rcl_ret_t
 rclc_diagnostic_task_init(
   diagnostic_task_t * task,
-  const char * name,
-  const char * (*function)(void));
+  const unsigned int id,
+  rcl_ret_t (*function)(diagnostic_value_t*));
 
 rcl_ret_t
 rclc_diagnostic_updater_init(
   diagnostic_updater_t * updater,
   const rcl_node_t * node,
-  const char * name,
-  const char * message,
-  const char * hardware_id);
+  const unsigned int id,
+  const unsigned int hardware_id);
 
 rcl_ret_t
 rclc_diagnostic_updater_fini(
@@ -69,7 +88,7 @@ rclc_diagnostic_updater_add_task(
   diagnostic_updater_t * updater,
   diagnostic_task_t * task);
 
-const char *
+rcl_ret_t
 rclc_diagnostic_call_task(
   diagnostic_task_t * task);
 


### PR DESCRIPTION
I gave it a shot and refactored micro-ROS diagnostic status to work without arrays and without strings. I added a new package `micro_ros_diagnostic_bridge`, which provides a ROS 2 node to run on the micro processor and translate micro-ROS diagnostic messages to vanilla ROS 2 diagnostic messages based on a lookup table.

See [micro_ros_diagnostic_updater/example](https://github.com/micro-ROS/micro_ros_diagnostics/tree/feature/un-string-ify/micro_ros_diagnostic_updater/example) for two example updaters and [example_table.yaml](https://github.com/micro-ROS/micro_ros_diagnostics/blob/feature/un-string-ify/micro_ros_diagnostic_bridge/example_table.yaml) for the corresponding lookup table.