### PR TITLE
Diagnostics topics configurable via cmake for bridge

### DIFF
--- a/micro_ros_diagnostic_bridge/CMakeLists.txt
+++ b/micro_ros_diagnostic_bridge/CMakeLists.txt
@@ -21,6 +21,14 @@ find_package(diagnostic_msgs REQUIRED)
 find_package(micro_ros_diagnostic_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 
+# configure diagnostics topics
+set(DIAGNOSTICS_TOPIC_IN "/diagnostics_uros" CACHE STRING "micro-ROS diagnostics topic to subscribe to")
+set(DIAGNOSTICS_TOPIC_OUT "/diagnostics" CACHE STRING "ROS diagnostics topic to publish to")
+configure_file(
+  include/${PROJECT_NAME}/topics.h.in
+  ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/topics.h)
+include_directories(BEFORE ${CMAKE_CURRENT_BINARY_DIR})
+
 # bridge executable
 include_directories(include)
 add_executable(diagnostic_bridge

--- a/micro_ros_diagnostic_bridge/include/micro_ros_diagnostic_bridge/micro_ros_diagnostic_bridge.hpp
+++ b/micro_ros_diagnostic_bridge/include/micro_ros_diagnostic_bridge/micro_ros_diagnostic_bridge.hpp
@@ -25,10 +25,7 @@
 
 #include "diagnostic_msgs/msg/diagnostic_status.hpp"
 #include "micro_ros_diagnostic_msgs/msg/micro_ros_diagnostic_status.hpp"
-
-
-static const char UROS_DIAGNOSTICS_BRIDGE_TOPIC_IN[] = "/diagnostics_uros";
-static const char UROS_DIAGNOSTICS_BRIDGE_TOPIC_OUT[] = "/diagnostics";
+#include "micro_ros_diagnostic_bridge/topics.h"
 
 namespace uros_diagnostic_msg = micro_ros_diagnostic_msgs::msg;
 namespace diagnostic_msg = diagnostic_msgs::msg;

--- a/micro_ros_diagnostic_bridge/include/micro_ros_diagnostic_bridge/topics.h.in
+++ b/micro_ros_diagnostic_bridge/include/micro_ros_diagnostic_bridge/topics.h.in
@@ -1,0 +1,4 @@
+#pragma once
+
+static const char UROS_DIAGNOSTICS_BRIDGE_TOPIC_IN[] = "@DIAGNOSTICS_TOPIC_IN@";
+static const char UROS_DIAGNOSTICS_BRIDGE_TOPIC_OUT[] = "@DIAGNOSTICS_TOPIC_OUT@";

--- a/micro_ros_diagnostic_updater/include/micro_ros_diagnostic_updater/micro_ros_diagnostic_updater.h
+++ b/micro_ros_diagnostic_updater/include/micro_ros_diagnostic_updater/micro_ros_diagnostic_updater.h
@@ -21,6 +21,9 @@
 #include <micro_ros_diagnostic_msgs/msg/micro_ros_diagnostic_status.h>
 
 #define MICRO_ROS_UPDATER_MAX_NUMBER_OF_TASKS 5
+#define MICRO_ROS_UPDATER_MAX_NUMBER_OF_TASKS 5
+
+static const char UROS_DIAGNOSTICS_UPDATER_TOPIC[] = "/diagnostics_uros";
 
 typedef struct diagnostic_value_t
 {


### PR DESCRIPTION
Make diagnostics topics configurable, see https://github.com/micro-ROS/micro_ros_diagnostics/issues/19

Signed-off-by: Nordmann Arne (CR/ADT3) <arne.nordmann@de.bosch.com>